### PR TITLE
Replace gnome-terminal starting with "qvm-start"

### DIFF
--- a/deb_upgrader.sh
+++ b/deb_upgrader.sh
@@ -38,7 +38,7 @@ upgrade_template() {
     fi
     
     message "Upgrading $new_template_name"
-    qvm-run -a $new_template_name gnome-terminal
+    qvm-start $new_template_name
     
     message "Updating APT repositories..."
     qvm-run -p $new_template_name "sudo sed -i 's/$old_name/$new_name/g' /etc/apt/sources.list"


### PR DESCRIPTION
Since this script is non-interactive, there's no need to start a gnome-terminal for the user to type commands. Implemented per Marek's suggestion [1]. This was replaced with `qvm-start`.

[1]: https://github.com/QubesOS/qubes-issues/issues/8605#issuecomment-1771378749